### PR TITLE
Vehicle entity, change in delete

### DIFF
--- a/src/vehicle/dto/create-vehicle.dto.ts
+++ b/src/vehicle/dto/create-vehicle.dto.ts
@@ -5,7 +5,6 @@ import { Vehicle } from "../entities/vehicle.entity";
 
 export class CreateVehicleDto extends PickType(Vehicle, [
     "residentId",
-    "color",
 ] as const) {
     /**
      * The photo must contain a license plate, otherwise the request will be rejected

--- a/src/vehicle/entities/vehicle.entity.ts
+++ b/src/vehicle/entities/vehicle.entity.ts
@@ -1,11 +1,4 @@
-import {
-    Column,
-    Entity,
-    ManyToOne,
-    PrimaryColumn,
-    Index,
-    JoinColumn,
-} from "typeorm";
+import { Column, Entity, ManyToOne, PrimaryColumn, JoinColumn } from "typeorm";
 import { Resident } from "../../resident/entities/resident.entity";
 import { IsEnum, IsString } from "class-validator";
 import { ApiProperty } from "@nestjs/swagger";
@@ -20,11 +13,6 @@ enum status {
 export class Vehicle {
     @PrimaryColumn()
     id: string;
-
-    @ApiProperty({ example: "Xanh" })
-    @IsString()
-    @Column()
-    color: string;
 
     @Column({ name: "license_plate", unique: true })
     licensePlate: string;

--- a/src/vehicle/vehicle.controller.ts
+++ b/src/vehicle/vehicle.controller.ts
@@ -64,9 +64,11 @@ export class VehicleController {
     @Delete("/:id")
     async deleteVehicle(@User() user: AccountOwner, @Param("id") id: string) {
         if (user?.role === PersonRole.RESIDENT) {
-            let resident = user as Resident;
-            if (resident.vehicles.findIndex((vehicle) => vehicle.id === id) < 0)
+            const residentVehicles =
+                await this.vehicleService.getAllVehicleByResidentId(user.id);
+            if (!residentVehicles.find((vehicle) => vehicle.id === id))
                 throw new NotFoundException("Vehicle not found");
-        } else await this.vehicleService.deleteVehicleById(id);
+        }
+        await this.vehicleService.deleteVehicleById(id);
     }
 }

--- a/src/vehicle/vehicle.controller.ts
+++ b/src/vehicle/vehicle.controller.ts
@@ -3,6 +3,7 @@ import {
     Controller,
     Delete,
     Get,
+    NotFoundException,
     Param,
     Patch,
     Post,
@@ -16,13 +17,14 @@ import { Auth } from "../helper/decorator/auth.decorator";
 import { User } from "../helper/decorator/user.decorator";
 import { AccountOwner } from "../auth/auth.service";
 import { UpdateVehicleDto } from "./dto/update-vehicle.dto";
+import { Resident } from "../resident/entities/resident.entity";
 
 @ApiTags("vehicle")
-@Auth(PersonRole.RESIDENT, PersonRole.MANAGER, PersonRole.ADMIN)
 @Controller("vehicle")
 export class VehicleController {
     constructor(private readonly vehicleService: VehicleService) {}
 
+    @Auth(PersonRole.RESIDENT, PersonRole.MANAGER, PersonRole.ADMIN)
     @Post("/")
     @FormDataRequest()
     @ApiConsumes("multipart/form-data")
@@ -37,6 +39,7 @@ export class VehicleController {
      * @param user user fetched from the token
      * @returns
      */
+    @Auth(PersonRole.RESIDENT, PersonRole.MANAGER, PersonRole.ADMIN)
     @Get("/")
     async getAllVehicle(@User() user: AccountOwner | null) {
         if (user?.role === PersonRole.RESIDENT) {
@@ -57,8 +60,13 @@ export class VehicleController {
         );
     }
 
+    @Auth(PersonRole.RESIDENT, PersonRole.MANAGER, PersonRole.ADMIN)
     @Delete("/:id")
-    async deleteVehicle(@Param("id") id: string) {
-        await this.vehicleService.deleteVehicleById(id);
+    async deleteVehicle(@User() user: AccountOwner, @Param("id") id: string) {
+        if (user?.role === PersonRole.RESIDENT) {
+            let resident = user as Resident;
+            if (resident.vehicles.findIndex((vehicle) => vehicle.id === id) < 0)
+                throw new NotFoundException("Vehicle not found");
+        } else await this.vehicleService.deleteVehicleById(id);
     }
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Swagger has been added/updated (for bug fixes/features)
- [x] Features/bug fixes have been manually tested

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix + feature


* **What is the current behavior?** (You can also link to an open issue here)
1. `DELETE /vehicle/:id` Delete a vehicle by id.
2. Vehicle have `color` 
* **What is the new behavior (if this is a feature change)?**
1. `DELETE /vehicle/:id` Delete a vehicle by id, if the user is a resident then only delete the vehicle of that resident, if user doesn't associated with that vehicle, throw 404
2. Remote `color` in vehicle


* **Other information**:

* **What case have you tested?** (Screenshot, cURL, ...)
---
CASE 1:
- Login with an admin account, create a new vehicle
- Login with a resident account different from the resident account associated with the vehicle, and delete that vehicle in the previous step



